### PR TITLE
Trying to reintroduce fix on SubFilteredPhToHtml

### DIFF
--- a/src/Filters/SubFilteredPhToHtml.php
+++ b/src/Filters/SubFilteredPhToHtml.php
@@ -24,6 +24,7 @@ class SubFilteredPhToHtml extends AbstractHandler {
         preg_match_all( '|<ph id\s*=\s*["\']mtc_[0-9]+["\'] equiv-text\s*=\s*["\']base64:([^"\']+)["\']\s*\/>|siU', $segment, $html, PREG_SET_ORDER ); // Ungreedy
         foreach ( $html as $subfilter_tag ) {
             $value = base64_decode( $subfilter_tag[ 1 ] );
+            //$value = html_entity_decode( $value, ENT_NOQUOTES | ENT_XML1 );
             $segment = str_replace( $subfilter_tag[0], $value, $segment );
         }
 

--- a/src/Filters/SubFilteredPhToHtml.php
+++ b/src/Filters/SubFilteredPhToHtml.php
@@ -24,7 +24,6 @@ class SubFilteredPhToHtml extends AbstractHandler {
         preg_match_all( '|<ph id\s*=\s*["\']mtc_[0-9]+["\'] equiv-text\s*=\s*["\']base64:([^"\']+)["\']\s*\/>|siU', $segment, $html, PREG_SET_ORDER ); // Ungreedy
         foreach ( $html as $subfilter_tag ) {
             $value = base64_decode( $subfilter_tag[ 1 ] );
-            $value = html_entity_decode( $value, ENT_NOQUOTES | ENT_XML1 );
             $segment = str_replace( $subfilter_tag[0], $value, $segment );
         }
 

--- a/tests/MateCatSubFilteringTest.php
+++ b/tests/MateCatSubFilteringTest.php
@@ -680,61 +680,41 @@ class MateCatSubFilteringTest extends TestCase
         $this->assertEquals($back_to_db_segment, $db_segment);
     }
 
-//    public function testXTags()
-//    {
-//        $Filter = MateCatFilter::getInstance( new FeatureSet(), 'en-EN','et-ET', [] );
-//
-//        $db_segment = '&lt;x id="3"/&gt;Primary Care Facilities&lt;x id="7"/&gt;';
-//        $expected_l1_segment = '<ph id="mtc_1" equiv-text="base64:Jmx0O3ggaWQ9IjMiLyZndDs="/>Primary Care Facilities<ph id="mtc_2" equiv-text="base64:Jmx0O3ggaWQ9IjciLyZndDs="/>';
-//        $expected_l2_segment = '&lt;ph id="mtc_1" equiv-text="base64:Jmx0O3ggaWQ9IjMiLyZndDs="/&gt;Primary Care Facilities&lt;ph id="mtc_2" equiv-text="base64:Jmx0O3ggaWQ9IjciLyZndDs="/&gt;';
-//
-//        $l1_segment     = $Filter->fromLayer0ToLayer1( $db_segment );
-//        $l2_segment     = $Filter->fromLayer1ToLayer2( $l1_segment );
-//
-//        $this->assertEquals($l1_segment, $expected_l1_segment);
-//        $this->assertEquals($l2_segment, $expected_l2_segment);
-//
-//        $back_to_db_segment = $Filter->fromLayer1ToLayer0($l1_segment);
-//
-//        $this->assertEquals($back_to_db_segment, $db_segment);
-//    }
-//
-//    public function testWithComplexUrls()
-//    {
-//        $Filter = MateCatFilter::getInstance( new FeatureSet(), 'en-EN','et-ET', [] );
-//
-//        $db_segment = '&lt;li&gt;Bergamo: &lt;a href="http://www.comune.bergamo.it/servizi/Menu/dinamica.aspx?idSezione=3780&amp;#38;idArea=1182&amp;#38;idCat=555&amp;#38;ID=28395&amp;#38;TipoElemento=categoria" target="_blank"&gt;Italian&lt;/a&gt; &lt;/li&gt;&#10;&#917760;';
-//        $expected_l1_segment = '<ph id="mtc_1" equiv-text="base64:Jmx0O2xpJmd0Ow=="/>Bergamo: <ph id="mtc_2" equiv-text="base64:Jmx0O2EgaHJlZj0iaHR0cDovL3d3dy5jb211bmUuYmVyZ2Ftby5pdC9zZXJ2aXppL01lbnUvZGluYW1pY2EuYXNweD9pZFNlemlvbmU9Mzc4MCZhbXA7IzM4O2lkQXJlYT0xMTgyJmFtcDsjMzg7aWRDYXQ9NTU1JmFtcDsjMzg7SUQ9MjgzOTUmYW1wOyMzODtUaXBvRWxlbWVudG89Y2F0ZWdvcmlhIiB0YXJnZXQ9Il9ibGFuayImZ3Q7"/>Italian<ph id="mtc_3" equiv-text="base64:Jmx0Oy9hJmd0Ow=="/> <ph id="mtc_4" equiv-text="base64:Jmx0Oy9saSZndDs="/>&#10;&#917760;';
-//        $expected_l2_segment = '&lt;ph id="mtc_1" equiv-text="base64:Jmx0O2xpJmd0Ow=="/&gt;Bergamo: &lt;ph id="mtc_2" equiv-text="base64:Jmx0O2EgaHJlZj0iaHR0cDovL3d3dy5jb211bmUuYmVyZ2Ftby5pdC9zZXJ2aXppL01lbnUvZGluYW1pY2EuYXNweD9pZFNlemlvbmU9Mzc4MCZhbXA7IzM4O2lkQXJlYT0xMTgyJmFtcDsjMzg7aWRDYXQ9NTU1JmFtcDsjMzg7SUQ9MjgzOTUmYW1wOyMzODtUaXBvRWxlbWVudG89Y2F0ZWdvcmlhIiB0YXJnZXQ9Il9ibGFuayImZ3Q7"/&gt;Italian&lt;ph id="mtc_3" equiv-text="base64:Jmx0Oy9hJmd0Ow=="/&gt; &lt;ph id="mtc_4" equiv-text="base64:Jmx0Oy9saSZndDs="/&gt;##$_0A$##󠄀';
-//
-//        $l1_segment     = $Filter->fromLayer0ToLayer1( $db_segment );
-//        $l2_segment     = $Filter->fromLayer1ToLayer2( $l1_segment );
-//
-//        $this->assertEquals($l1_segment, $expected_l1_segment);
-//        $this->assertEquals($l2_segment, $expected_l2_segment);
-//
-//        $back_to_db_segment = $Filter->fromLayer1ToLayer0($l1_segment);
-//
-//        $this->assertEquals($back_to_db_segment, $db_segment);
-//
-//    }
+    public function testXTags()
+    {
+        $Filter = MateCatFilter::getInstance( new FeatureSet(), 'en-EN','et-ET', [] );
 
-//    public function testWithEncodedText()
-//    {
-//        $Filter = MateCatFilter::getInstance( new FeatureSet(), 'en-EN','et-ET', [] );
-//
-//        $db_segment = '&lt;x id="3"/&gt;Primary Care Facilities&lt;x id="7"/&gt;';
-//        $expected_l1_segment = '<ph id="mtc_1" equiv-text="base64:Jmx0O3ggaWQ9IjMiLyZndDs="/>Primary Care Facilities<ph id="mtc_2" equiv-text="base64:Jmx0O3ggaWQ9IjciLyZndDs="/>';
-//        $expected_l2_segment = '&lt;ph id="mtc_1" equiv-text="base64:Jmx0O3ggaWQ9IjMiLyZndDs="/&gt;Primary Care Facilities&lt;ph id="mtc_2" equiv-text="base64:Jmx0O3ggaWQ9IjciLyZndDs="/&gt;';
-//
-//        $l1_segment     = $Filter->fromLayer0ToLayer1( $db_segment );
-//        $l2_segment     = $Filter->fromLayer1ToLayer2( $l1_segment );
-//
-//        $this->assertEquals($l1_segment, $expected_l1_segment);
-//        $this->assertEquals($l2_segment, $expected_l2_segment);
-//
-//        $back_to_db_segment = $Filter->fromLayer1ToLayer0($l1_segment);
-//
-//        $this->assertEquals($back_to_db_segment, $db_segment);
-//    }
+        $db_segment = '<x id="3"/>Primary Care Facilities<x id="7"/>';
+        $expected_l1_segment = '<x id="3"/>Primary Care Facilities<x id="7"/>';
+        $expected_l2_segment = '&lt;x id="3"/&gt;Primary Care Facilities&lt;x id="7"/&gt;';
+
+        $l1_segment     = $Filter->fromLayer0ToLayer1( $db_segment );
+        $l2_segment     = $Filter->fromLayer1ToLayer2( $l1_segment );
+
+        $this->assertEquals($l1_segment, $expected_l1_segment);
+        $this->assertEquals($l2_segment, $expected_l2_segment);
+
+        $back_to_db_segment = $Filter->fromLayer1ToLayer0($l1_segment);
+
+        $this->assertEquals($back_to_db_segment, $db_segment);
+    }
+
+    public function testWithEncodedText()
+    {
+        $Filter = MateCatFilter::getInstance( new FeatureSet(), 'en-EN','et-ET', [] );
+
+        $db_segment = '&lt;x id="3"/&gt;Primary Care Facilities&lt;x id="7"/&gt;';
+        $expected_l1_segment = '<ph id="mtc_1" equiv-text="base64:Jmx0O3ggaWQ9IjMiLyZndDs="/>Primary Care Facilities<ph id="mtc_2" equiv-text="base64:Jmx0O3ggaWQ9IjciLyZndDs="/>';
+        $expected_l2_segment = '&lt;ph id="mtc_1" equiv-text="base64:Jmx0O3ggaWQ9IjMiLyZndDs="/&gt;Primary Care Facilities&lt;ph id="mtc_2" equiv-text="base64:Jmx0O3ggaWQ9IjciLyZndDs="/&gt;';
+
+        $l1_segment     = $Filter->fromLayer0ToLayer1( $db_segment );
+        $l2_segment     = $Filter->fromLayer1ToLayer2( $l1_segment );
+
+        $this->assertEquals($l1_segment, $expected_l1_segment);
+        $this->assertEquals($l2_segment, $expected_l2_segment);
+
+        $back_to_db_segment = $Filter->fromLayer1ToLayer0($l1_segment);
+
+        $this->assertEquals($back_to_db_segment, $db_segment);
+    }
 }

--- a/tests/MateCatSubFilteringTest.php
+++ b/tests/MateCatSubFilteringTest.php
@@ -699,6 +699,15 @@ class MateCatSubFilteringTest extends TestCase
         $this->assertEquals($back_to_db_segment, $db_segment);
     }
 
+    /**
+     * This test is RED if the function:
+     *
+     * $value = html_entity_decode( $value, ENT_NOQUOTES | ENT_XML1 );
+     *
+     * inside SubFilteredPhToHtml is enabled
+     *
+     * @throws \Exception
+     */
     public function testWithEncodedText()
     {
         $Filter = MateCatFilter::getInstance( new FeatureSet(), 'en-EN','et-ET', [] );
@@ -706,6 +715,34 @@ class MateCatSubFilteringTest extends TestCase
         $db_segment = '&lt;x id="3"/&gt;Primary Care Facilities&lt;x id="7"/&gt;';
         $expected_l1_segment = '<ph id="mtc_1" equiv-text="base64:Jmx0O3ggaWQ9IjMiLyZndDs="/>Primary Care Facilities<ph id="mtc_2" equiv-text="base64:Jmx0O3ggaWQ9IjciLyZndDs="/>';
         $expected_l2_segment = '&lt;ph id="mtc_1" equiv-text="base64:Jmx0O3ggaWQ9IjMiLyZndDs="/&gt;Primary Care Facilities&lt;ph id="mtc_2" equiv-text="base64:Jmx0O3ggaWQ9IjciLyZndDs="/&gt;';
+
+        $l1_segment     = $Filter->fromLayer0ToLayer1( $db_segment );
+        $l2_segment     = $Filter->fromLayer1ToLayer2( $l1_segment );
+
+        $this->assertEquals($l1_segment, $expected_l1_segment);
+        $this->assertEquals($l2_segment, $expected_l2_segment);
+
+        $back_to_db_segment = $Filter->fromLayer1ToLayer0($l1_segment);
+
+        $this->assertEquals($back_to_db_segment, $db_segment);
+    }
+
+    /**
+     * This test is GREEN independently if the function:
+     *
+     * $value = html_entity_decode( $value, ENT_NOQUOTES | ENT_XML1 );
+     *
+     * inside SubFilteredPhToHtml is enabled or not
+     *
+     * @throws \Exception
+     */
+    public function testWithEncodedAnchor()
+    {
+        $Filter = MateCatFilter::getInstance( new FeatureSet(), 'en-EN','et-ET', [] );
+
+        $db_segment = '&lt;a href="#"&gt;Link&lt;/a&gt;';
+        $expected_l1_segment = '<ph id="mtc_1" equiv-text="base64:Jmx0O2EgaHJlZj0iIyImZ3Q7"/>Link<ph id="mtc_2" equiv-text="base64:Jmx0Oy9hJmd0Ow=="/>';
+        $expected_l2_segment = '&lt;ph id="mtc_1" equiv-text="base64:Jmx0O2EgaHJlZj0iIyImZ3Q7"/&gt;Link&lt;ph id="mtc_2" equiv-text="base64:Jmx0Oy9hJmd0Ow=="/&gt;';
 
         $l1_segment     = $Filter->fromLayer0ToLayer1( $db_segment );
         $l2_segment     = $Filter->fromLayer1ToLayer2( $l1_segment );


### PR DESCRIPTION
@Ostico I am trying to reintroduce the fix recently reverted.

`SubFilteredPhToHtml` will decode every HTML content inside matecat ph tag. I am not sure that it's correct.

For example, consider this string coming from DB layer (layer0):

``` 
&lt;x id="3"/&gt;
```

`MateCatFilter::fromLayer0ToLayer1` method (correctly) converts it to: 

```
<ph id="mtc_1" equiv-text="base64:Jmx0O3ggaWQ9IjMiLyZndDs="/>
```

Instead `MateCatFilter::fromLayer1ToLayer0` method converts it to: 

``` 
<x id="3"/>
```

due to html_entity_decode function in `SubFilteredPhToHtml`:

```php
$value = html_entity_decode( $value, ENT_NOQUOTES | ENT_XML1 );
```

Please check the test named `testWithEncodedText` within `MateCatSubFilteringTest` class for the full example.

