### PR TITLE
[FIX] Handle encoded xliff tags

### DIFF
--- a/src/Commons/Constants.php
+++ b/src/Commons/Constants.php
@@ -17,4 +17,7 @@ class Constants {
 
     const splitPlaceHolder = '##$_SPLIT$##';
 
+    const xliffInXliffStartPlaceHolder = '##XLIFFTAGPLACEHOLDER_START##';
+    const xliffInXliffEndPlaceHolder = '##XLIFFTAGPLACEHOLDER_END##';
+
 }

--- a/src/Filters/RestoreXliffTagsInXliff.php
+++ b/src/Filters/RestoreXliffTagsInXliff.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Matecat\SubFiltering\Filters;
+
+use Matecat\SubFiltering\Commons\AbstractHandler;
+use Matecat\SubFiltering\Commons\Constants;
+
+class RestoreXliffTagsInXliff extends AbstractHandler {
+
+    /**
+     * @inheritDoc
+     */
+    public function transform( $segment )
+    {
+        $segment = str_replace( Constants::xliffInXliffStartPlaceHolder, "&lt;", $segment );
+        $segment = str_replace( Constants::xliffInXliffEndPlaceHolder, "&gt;", $segment );
+
+        return $segment;
+    }
+}

--- a/src/Filters/SubFilteredPhToHtml.php
+++ b/src/Filters/SubFilteredPhToHtml.php
@@ -1,15 +1,9 @@
 <?php
-/**
- * Created by PhpStorm.
- * @author domenico domenico@translated.net / ostico@gmail.com
- * Date: 05/11/18
- * Time: 15.30
- *
- */
 
 namespace Matecat\SubFiltering\Filters;
 
 use Matecat\SubFiltering\Commons\AbstractHandler;
+use Matecat\SubFiltering\Commons\Constants;
 
 class SubFilteredPhToHtml extends AbstractHandler {
 
@@ -18,26 +12,64 @@ class SubFilteredPhToHtml extends AbstractHandler {
      *
      * @return string
      */
-    public function transform( $segment ){
-
+    public function transform( $segment )
+    {
         // pipeline for restore PH tag of subfiltering to original encoded HTML
         preg_match_all( '|<ph id\s*=\s*["\']mtc_[0-9]+["\'] equiv-text\s*=\s*["\']base64:([^"\']+)["\']\s*\/>|siU', $segment, $html, PREG_SET_ORDER ); // Ungreedy
         foreach ( $html as $subfilter_tag ) {
             $value = base64_decode( $subfilter_tag[ 1 ] );
-
-            // @TODO issue of xliff tag inside xliff:
-            // <source> &lt;g&gt; pippo &lt;/g&gt; </source>
-            // here we know exactly that those xliff tags are encoded
-            // we have to placehold them to avoid PlaceHoldXliffTags handle them as really xliff tag
-            // we must add another layer after PlaceHoldXliffTags to restore the original values so the HtmlPlainTextDecoder can do it's job
-
+            $value = $this->placeholdXliffTagsInXliff($value);
             $value = html_entity_decode( $value, ENT_NOQUOTES | ENT_XML1 );
             $segment = str_replace( $subfilter_tag[0], $value, $segment );
 
         }
 
         return $segment;
-
     }
 
+    /**
+     * Protect the xliff tag inside a xliff:
+     *
+     * Example: <source> &lt;g&gt; pippo &lt;/g&gt; </source>
+     *
+     * We have to placehold them to avoid PlaceHoldXliffTags handle them as really xliff tag.
+     * Then we add another layer after PlaceHoldXliffTags to restore the original values so the HtmlPlainTextDecoder can do it's job.
+     *
+     * @param string $value
+     *
+     * @return mixed
+     */
+    private function placeholdXliffTagsInXliff($value)
+    {
+        $value = preg_replace( '|(&lt;/x&gt;)|si', "", $value );
+        $value = preg_replace( '|&lt;(g\s*id=["\']+.*?["\']+\s*[^&lt;&gt;]*?)&gt;|si', Constants::xliffInXliffStartPlaceHolder . "$1" . Constants::xliffInXliffEndPlaceHolder, $value );
+
+        $value = preg_replace( '|&lt;(/g)&gt;|si', Constants::xliffInXliffStartPlaceHolder . "$1" . Constants::xliffInXliffEndPlaceHolder, $value );
+
+        $value = preg_replace( '|&lt;(x .*?/?)&gt;|si', Constants::xliffInXliffStartPlaceHolder . "$1" . Constants::xliffInXliffEndPlaceHolder, $value );
+        $value = preg_replace( '#&lt;(bx[ ]{0,}/?|bx .*?/?)&gt;#si', Constants::xliffInXliffStartPlaceHolder . "$1" . Constants::xliffInXliffEndPlaceHolder, $value );
+        $value = preg_replace( '#&lt;(ex[ ]{0,}/?|ex .*?/?)&gt;#si', Constants::xliffInXliffStartPlaceHolder . "$1" . Constants::xliffInXliffEndPlaceHolder, $value );
+        $value = preg_replace( '|&lt;(bpt\s*.*?)&gt;|si', Constants::xliffInXliffStartPlaceHolder . "$1" . Constants::xliffInXliffEndPlaceHolder, $value );
+        $value = preg_replace( '|&lt;(/bpt)&gt;|si', Constants::xliffInXliffStartPlaceHolder . "$1" . Constants::xliffInXliffEndPlaceHolder, $value );
+        $value = preg_replace( '|&lt;(ept\s*.*?)&gt;|si', Constants::xliffInXliffStartPlaceHolder . "$1" . Constants::xliffInXliffEndPlaceHolder, $value );
+        $value = preg_replace( '|&lt;(/ept)&gt;|si', Constants::xliffInXliffStartPlaceHolder . "$1" . Constants::xliffInXliffEndPlaceHolder, $value );
+        $value = preg_replace( '|&lt;(ph .*?)&gt;|si', Constants::xliffInXliffStartPlaceHolder . "$1" . Constants::xliffInXliffEndPlaceHolder, $value );
+        $value = preg_replace( '|&lt;(/ph)&gt;|si', Constants::xliffInXliffStartPlaceHolder . "$1" . Constants::xliffInXliffEndPlaceHolder, $value );
+        $value = preg_replace( '|&lt;(ec .*?)&gt;|si', Constants::xliffInXliffStartPlaceHolder . "$1" . Constants::xliffInXliffEndPlaceHolder, $value );
+        $value = preg_replace( '|&lt;(/ec)&gt;|si', Constants::xliffInXliffStartPlaceHolder . "$1" . Constants::xliffInXliffEndPlaceHolder, $value );
+        $value = preg_replace( '|&lt;(sc .*?)&gt;|si', Constants::xliffInXliffStartPlaceHolder . "$1" . Constants::xliffInXliffEndPlaceHolder, $value );
+        $value = preg_replace( '|&lt;(/sc)&gt;|si', Constants::xliffInXliffStartPlaceHolder . "$1" . Constants::xliffInXliffEndPlaceHolder, $value );
+        $value = preg_replace( '|&lt;(pc .*?)&gt;|si', Constants::xliffInXliffStartPlaceHolder . "$1" . Constants::xliffInXliffEndPlaceHolder, $value );
+        $value = preg_replace( '|&lt;(/pc)&gt;|si', Constants::xliffInXliffStartPlaceHolder . "$1" . Constants::xliffInXliffEndPlaceHolder, $value );
+        $value = preg_replace( '|&lt;(it .*?)&gt;|si', Constants::xliffInXliffStartPlaceHolder . "$1" . Constants::xliffInXliffEndPlaceHolder, $value );
+        $value = preg_replace( '|&lt;(/it)&gt;|si', Constants::xliffInXliffStartPlaceHolder . "$1" . Constants::xliffInXliffEndPlaceHolder, $value );
+        $value = preg_replace( '|&lt;(mrk\s*.*?)&gt;|si', Constants::xliffInXliffStartPlaceHolder . "$1" . Constants::xliffInXliffEndPlaceHolder, $value );
+        $value = preg_replace( '|&lt;(/mrk)&gt;|si', Constants::xliffInXliffStartPlaceHolder . "$1" . Constants::xliffInXliffEndPlaceHolder, $value );
+
+        return preg_replace_callback( '/' . Constants::xliffInXliffStartPlaceHolder . '(.*?)' . Constants::xliffInXliffEndPlaceHolder . '/u',
+                function ( $matches ) {
+                    return Constants::xliffInXliffStartPlaceHolder . $matches[ 1 ] . Constants::xliffInXliffEndPlaceHolder;
+                }, $value
+        );
+    }
 }

--- a/src/Filters/SubFilteredPhToHtml.php
+++ b/src/Filters/SubFilteredPhToHtml.php
@@ -24,8 +24,16 @@ class SubFilteredPhToHtml extends AbstractHandler {
         preg_match_all( '|<ph id\s*=\s*["\']mtc_[0-9]+["\'] equiv-text\s*=\s*["\']base64:([^"\']+)["\']\s*\/>|siU', $segment, $html, PREG_SET_ORDER ); // Ungreedy
         foreach ( $html as $subfilter_tag ) {
             $value = base64_decode( $subfilter_tag[ 1 ] );
+
+            // @TODO issue of xliff tag inside xliff:
+            // <source> &lt;g&gt; pippo &lt;/g&gt; </source>
+            // here we know exactly that those xliff tags are encoded
+            // we have to placehold them to avoid PlaceHoldXliffTags handle them as really xliff tag
+            // we must add another layer after PlaceHoldXliffTags to restore the original values so the HtmlPlainTextDecoder can do it's job
+
             $value = html_entity_decode( $value, ENT_NOQUOTES | ENT_XML1 );
             $segment = str_replace( $subfilter_tag[0], $value, $segment );
+
         }
 
         return $segment;

--- a/src/MateCatFilter.php
+++ b/src/MateCatFilter.php
@@ -23,6 +23,7 @@ use Matecat\SubFiltering\Filters\RestorePlaceHoldersToXLIFFLtGt;
 use Matecat\SubFiltering\Filters\RestoreTabsPlaceholders;
 use Matecat\SubFiltering\Filters\RestoreXliffTagsContent;
 use Matecat\SubFiltering\Filters\RestoreXliffTagsForView;
+use Matecat\SubFiltering\Filters\RestoreXliffTagsInXliff;
 use Matecat\SubFiltering\Filters\SpacesToNBSPForView;
 use Matecat\SubFiltering\Filters\SplitPlaceholder;
 use Matecat\SubFiltering\Filters\SprintfToPH;
@@ -175,6 +176,7 @@ class MateCatFilter extends AbstractFilter {
         $channel->addLast( new MateCatCustomPHToStandardPH() );
         $channel->addLast( new SubFilteredPhToHtml() );
         $channel->addLast( new PlaceHoldXliffTags() );
+        $channel->addLast( new RestoreXliffTagsInXliff() );
         $channel->addLast( new HtmlPlainTextDecoder() );
         $channel->addLast( new EncodeToRawXML() );
         $channel->addLast( new LtGtEncode() );

--- a/tests/MateCatSubFilteringTest.php
+++ b/tests/MateCatSubFilteringTest.php
@@ -271,6 +271,31 @@ class MateCatSubFilteringTest extends TestCase
 
     /**
      **************************
+     * Tag <x> <g>
+     **************************
+     */
+
+    public function testFilterWithTagGAndX() {
+
+        $Filter = MateCatFilter::getInstance( new FeatureSet(), 'en-EN', 'et-ET', [] );
+
+        $db_segment          = '&lt;g id="1"&gt;';
+        $expected_l1_segment = '<ph id="mtc_1" equiv-text="base64:Jmx0O2cgaWQ9IjEiJmd0Ow=="/>';
+        $expected_l2_segment = '&lt;ph id="mtc_1" equiv-text="base64:Jmx0O2cgaWQ9IjEiJmd0Ow=="/&gt;';
+
+        $l1_segment = $Filter->fromLayer0ToLayer1( $db_segment );
+        $l2_segment = $Filter->fromLayer1ToLayer2( $l1_segment );
+
+        $this->assertEquals( $l1_segment, $expected_l1_segment );
+        $this->assertEquals( $l2_segment, $expected_l2_segment );
+
+        $back_to_db = $Filter->fromLayer1ToLayer0( $expected_l1_segment );
+
+        $this->assertEquals( $db_segment, $back_to_db );
+    }
+
+    /**
+     **************************
      * TWIG
      **************************
      */

--- a/tests/MateCatSubFilteringTest.php
+++ b/tests/MateCatSubFilteringTest.php
@@ -271,27 +271,47 @@ class MateCatSubFilteringTest extends TestCase
 
     /**
      **************************
-     * Tag <x> <g>
+     * Tag XLIFF inside a XLIFF
      **************************
      */
 
-    public function testFilterWithTagGAndX() {
+    public function testXliffTagsInsideAXliffFile() {
 
         $Filter = MateCatFilter::getInstance( new FeatureSet(), 'en-EN', 'et-ET', [] );
 
-        $db_segment          = '&lt;g id="1"&gt;';
-        $expected_l1_segment = '<ph id="mtc_1" equiv-text="base64:Jmx0O2cgaWQ9IjEiJmd0Ow=="/>';
-        $expected_l2_segment = '&lt;ph id="mtc_1" equiv-text="base64:Jmx0O2cgaWQ9IjEiJmd0Ow=="/&gt;';
+        $xliffTags = [
+            [
+                'db_segment' => '&lt;g id="1"&gt;',
+                'expected_l1_segment' => '<ph id="mtc_1" equiv-text="base64:Jmx0O2cgaWQ9IjEiJmd0Ow=="/>',
+                'expected_l2_segment' => '&lt;ph id="mtc_1" equiv-text="base64:Jmx0O2cgaWQ9IjEiJmd0Ow=="/&gt;',
+            ],
+            [
+                'db_segment' => '&lt;x id="1"/&gt;',
+                'expected_l1_segment' => '<ph id="mtc_1" equiv-text="base64:Jmx0O3ggaWQ9IjEiLyZndDs="/>',
+                'expected_l2_segment' => '&lt;ph id="mtc_1" equiv-text="base64:Jmx0O3ggaWQ9IjEiLyZndDs="/&gt;',
+            ],
+            [
+                'db_segment' => '&lt;pc id="1"&gt;',
+                'expected_l1_segment' => '<ph id="mtc_1" equiv-text="base64:Jmx0O3BjIGlkPSIxIiZndDs="/>',
+                'expected_l2_segment' => '&lt;ph id="mtc_1" equiv-text="base64:Jmx0O3BjIGlkPSIxIiZndDs="/&gt;',
+            ],
+        ];
 
-        $l1_segment = $Filter->fromLayer0ToLayer1( $db_segment );
-        $l2_segment = $Filter->fromLayer1ToLayer2( $l1_segment );
+        foreach ($xliffTags as $xliffTag){
+            $db_segment          = $xliffTag['db_segment'];
+            $expected_l1_segment = $xliffTag['expected_l1_segment'];
+            $expected_l2_segment = $xliffTag['expected_l2_segment'];
 
-        $this->assertEquals( $l1_segment, $expected_l1_segment );
-        $this->assertEquals( $l2_segment, $expected_l2_segment );
+            $l1_segment = $Filter->fromLayer0ToLayer1( $db_segment );
+            $l2_segment = $Filter->fromLayer1ToLayer2( $l1_segment );
 
-        $back_to_db = $Filter->fromLayer1ToLayer0( $expected_l1_segment );
+            $this->assertEquals( $l1_segment, $expected_l1_segment );
+            $this->assertEquals( $l2_segment, $expected_l2_segment );
 
-        $this->assertEquals( $db_segment, $back_to_db );
+            $back_to_db = $Filter->fromLayer1ToLayer0( $expected_l1_segment );
+
+            $this->assertEquals( $db_segment, $back_to_db );
+        }
     }
 
     /**


### PR DESCRIPTION
Encoded xliff tags (like `&lt;g id=&quote;1&quote;&gt; pippo &lt;/g&gt;`) must be handled correcly.

TODO List:

- here we know exactly that those xliff tags are encoded
- we have to insert a placeholder to avoid PlaceHoldXliffTags handling them as really xliff tag
- we must add another layer after PlaceHoldXliffTags to restore the original values so the HtmlPlainTextDecoder can do its job

Please refer to this test: `testFilterWithTagGAndX`